### PR TITLE
Changing the drain monitor to match the rest of the monitors using ti…

### DIFF
--- a/realis_e2e_test.go
+++ b/realis_e2e_test.go
@@ -94,6 +94,11 @@ func TestRealisClient_CreateJob_Thermos(t *testing.T) {
 	assert.Equal(t, aurora.ResponseCode_OK, resp.ResponseCode)
 	fmt.Printf("Create call took %d ns\n", (end.UnixNano() - start.UnixNano()))
 
+	// Test Instances Monitor
+	success, err := monitor.Instances(job.JobKey(), job.GetInstanceCount(), 1, 50)
+	assert.True(t, success)
+	assert.NoError(t, err)
+
 	// Tasks must exist for it to be killed
 	t.Run("TestRealisClient_KillJob_Thermos", func(t *testing.T) {
 		start := time.Now()
@@ -166,8 +171,8 @@ func TestRealisClient_DrainHosts(t *testing.T) {
 	hostResults, err := monitor.HostMaintenance(
 		hosts,
 		[]aurora.MaintenanceMode{aurora.MaintenanceMode_DRAINED, aurora.MaintenanceMode_DRAINING},
-		5,
-		10)
+		1,
+		50)
 	assert.Equal(t, map[string]bool{"192.168.33.7": true}, hostResults)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
…mer and ticker. Made a generic schedule status monitor that can be used with any of the default sets provided.

Before submitting, please make sure you run a vagrant box running Aurora with the latest version shown in .auroraversion
and run go test from the project root.

To run an Aurora Vagrant image, follow the instructions here:
http://aurora.apache.org/documentation/latest/getting-started/vagrant/

* Have you run goformat on the project before submitting? Yes

* Have you run go test on the project before submitting? Do all tests pass? Yes, Yes

* Does the Pull Request require a test to be added to the end to end tests? If so, has it been added? Yes, Yes