### PR TITLE
Introducing temporary errors. Refactored reestablish connection code …

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package realis
+
+// Using a pattern described by Dave Cheney to differentiate errors
+// https://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully
+type timeout interface {
+	Timeout() bool
+}
+
+func IsTimeout(err error) bool {
+	temp, ok := err.(timeout)
+	return ok && temp.Timeout()
+}
+
+type TimeoutErr struct {
+	error
+	timeout bool
+}
+
+func (t TimeoutErr) Timeout() bool {
+	return t.timeout
+}
+
+func NewTimeoutError(err error) TimeoutErr {
+	return TimeoutErr{error: err, timeout: true}
+}
+
+type temporary interface {
+	Temporary() bool
+}
+
+func IsTemporary(err error) bool {
+	temp, ok := err.(temporary)
+	return ok && temp.Temporary()
+}
+
+type TemporaryErr struct {
+	error
+	temporary bool
+}
+
+func (t TemporaryErr) Temporary() bool {
+	return t.temporary
+}
+
+// Retrying after receiving this error is advised
+func NewTemporaryError(err error) TemporaryErr {
+	return TemporaryErr{error: err, temporary: true}
+}
+
+// Nothing can be done about this error
+func NewPermamentError(err error) TemporaryErr {
+	return TemporaryErr{error: err, temporary: false}
+}

--- a/errors.go
+++ b/errors.go
@@ -32,12 +32,12 @@ type TimeoutErr struct {
 	timeout bool
 }
 
-func (t TimeoutErr) Timeout() bool {
+func (t *TimeoutErr) Timeout() bool {
 	return t.timeout
 }
 
-func NewTimeoutError(err error) TimeoutErr {
-	return TimeoutErr{error: err, timeout: true}
+func NewTimeoutError(err error) *TimeoutErr {
+	return &TimeoutErr{error: err, timeout: true}
 }
 
 type temporary interface {
@@ -54,13 +54,13 @@ type TemporaryErr struct {
 	temporary bool
 }
 
-func (t TemporaryErr) Temporary() bool {
+func (t *TemporaryErr) Temporary() bool {
 	return t.temporary
 }
 
 // Retrying after receiving this error is advised
-func NewTemporaryError(err error) TemporaryErr {
-	return TemporaryErr{error: err, temporary: true}
+func NewTemporaryError(err error) *TemporaryErr {
+	return &TemporaryErr{error: err, temporary: true}
 }
 
 // Nothing can be done about this error

--- a/realis_e2e_test.go
+++ b/realis_e2e_test.go
@@ -36,13 +36,13 @@ func TestMain(m *testing.M) {
 	// New configuration to connect to Vagrant image
 	r, err = realis.NewRealisClient(realis.SchedulerUrl("http://192.168.33.7:8081"),
 		realis.BasicAuth("aurora", "secret"),
-		realis.ThriftJSON(),
-		realis.TimeoutMS(20000),
-		realis.BackOff(&realis.Backoff{Steps: 2, Duration: 10 * time.Second, Factor: 2.0, Jitter: 0.1}))
+		realis.TimeoutMS(20000))
 	if err != nil {
 		fmt.Println("Please run vagrant box before running test suite")
 		os.Exit(1)
 	}
+
+	defer r.Close()
 
 	// Create monitor
 	monitor = &realis.Monitor{Client: r}
@@ -62,6 +62,14 @@ func TestLeaderFromZK(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, "http://aurora.local:8081", url)
+}
+
+func TestRealisClient_ReestablishConn(t *testing.T) {
+
+	// Test that we're able to tear down the old connection and create a new one.
+	err := r.ReestablishConn()
+
+	assert.NoError(t, err)
 }
 
 func TestGetCacerts(t *testing.T) {

--- a/retry.go
+++ b/retry.go
@@ -83,7 +83,7 @@ func ExponentialBackoff(backoff Backoff, condition ConditionFunc) error {
 func CheckAndRetryConn(r Realis, auroraCall AuroraThriftCall) (*aurora.Response, error) {
 	resp, cliErr := auroraCall()
 
-	// TODO: Rerturn different error type based on the error that was returned by the API call
+	// TODO: Return different error type based on the error that was returned by the API call
 	if cliErr != nil {
 		r.ReestablishConn()
 		return resp, NewPermamentError(RetryConnErr)

--- a/zk.go
+++ b/zk.go
@@ -48,7 +48,7 @@ func LeaderFromZK(cluster Cluster) (string, error) {
 		//TODO (rdelvalle): When enabling debugging, change logger here
 		c, _, err := zk.Connect(endpoints, time.Second*10, func(c *zk.Conn) { c.SetLogger(NoopLogger{}) })
 		if err != nil {
-			return false, errors.Wrap(err, "Failed to connect to Zookeeper at "+cluster.ZK)
+			return false, NewTemporaryError(errors.Wrap(err, "Failed to connect to Zookeeper at "+cluster.ZK))
 		}
 
 		defer c.Close()
@@ -73,7 +73,7 @@ func LeaderFromZK(cluster Cluster) (string, error) {
 
 				err = json.Unmarshal([]byte(data), serviceInst)
 				if err != nil {
-					return false, errors.Wrap(err, "Unable to unmarshall contents of leader")
+					return false, NewTemporaryError(errors.Wrap(err, "Unable to unmarshall contents of leader"))
 				}
 
 				// Should only be one endpoint


### PR DESCRIPTION
…to use NewClien. Added reestablish connection test to end to end tests.

First PR on the way to fixing nil buffer error caused by Thrift library for 0.10.0.

-----------------------------------------
## Please read instructions below ##

Before submitting, please make sure you run a vagrant box running Aurora with the latest version shown in .auroraversion and run go test from the project root.

To run an Aurora Vagrant image, follow the instructions here:
http://aurora.apache.org/documentation/latest/getting-started/vagrant/

* Have you run goformat on the project before submitting? Yes

* Have you run go test on the project before submitting? Do all tests pass? Yes, Yes

* Does the Pull Request require a test to be added to the end to end tests? If so, has it been added? Yes. Yes