### PR TITLE
Simplifying retry mechanism for Thrift Calls

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -16,6 +16,8 @@ package realis
 
 // Using a pattern described by Dave Cheney to differentiate errors
 // https://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully
+
+// Timeout errors are returned when a function has unsuccessfully retried.
 type timeout interface {
 	Timeout() bool
 }
@@ -38,6 +40,7 @@ func NewTimeoutError(err error) *TimeoutErr {
 	return &TimeoutErr{error: err, timeout: true}
 }
 
+// Temporary errors indicate that the action may and should be retried.
 type temporary interface {
 	Temporary() bool
 }
@@ -59,9 +62,4 @@ func (t *TemporaryErr) Temporary() bool {
 // Retrying after receiving this error is advised
 func NewTemporaryError(err error) *TemporaryErr {
 	return &TemporaryErr{error: err, temporary: true}
-}
-
-// Nothing can be done about this error
-func NewPermamentError(err error) TemporaryErr {
-	return TemporaryErr{error: err, temporary: false}
 }

--- a/zk.go
+++ b/zk.go
@@ -93,11 +93,12 @@ func LeaderFromZK(cluster Cluster) (string, error) {
 			}
 		}
 
-		return false, errors.New("No leader found")
+		// Leader data might not be available yet, try to fetch again.
+		return false, NewTemporaryError(errors.New("No leader found"))
 	})
 
 	if retryErr != nil {
-		return "", errors.Wrapf(retryErr, "Failed to determine leader after %v attempts", defaultBackoff.Steps)
+		return "", NewTimeoutError(errors.Wrapf(retryErr, "Failed to determine leader after %v attempts", defaultBackoff.Steps))
 	}
 
 	return zkurl, nil


### PR DESCRIPTION
* Changing paradigm from double closure to single closure for thrift calls.

* Splitting backoff functions into two, a generic one and one for thrift calls.

* Deleted permanent error as it's not necessary.

* ZK now continues to retry after it's unable to find a leader.

-----------------------------------------
* Have you run goformat on the project before submitting? Yes

* Have you run go test on the project before submitting? Do all tests pass? Yes, Yes

* Does the Pull Request require a test to be added to the end to end tests? If so, has it been added? No