### PR TITLE
Adding Admin Client calls `GetQuota` & `SetQuota`

### DIFF
--- a/realis_e2e_test.go
+++ b/realis_e2e_test.go
@@ -392,23 +392,34 @@ func TestRealisClient_SessionThreadSafety(t *testing.T) {
 
 // Test setting and getting the quota
 func TestRealisClient_SetQuota(t *testing.T) {
-	var cpu = 2.5
-	var ram int64 = 10240
+	var cpu = 3.5
+	var ram int64 = 20480
 	var disk int64 = 10240
-	resp, err := r.SetQuota("vagrant", cpu, ram, disk)
+	resp, err := r.SetQuota("vagrant", &cpu, &ram, &disk)
 	assert.NoError(t, err)
 	assert.Equal(t, aurora.ResponseCode_OK, resp.ResponseCode)
-
-	// Test GetQuota based on previously set values
-	var result *aurora.GetQuotaResult_
-	resp, err = r.GetQuota("vagrant")
-	if resp.GetResult_() != nil {
-		result = resp.GetResult_().GetQuotaResult_
-	}
-	assert.NoError(t, err)
-	assert.Equal(t, aurora.ResponseCode_OK, resp.ResponseCode)
-	assert.Equal(t, cpu, result.Quota.NumCpus)
-	assert.Equal(t, ram, result.Quota.RamMb)
-	assert.Equal(t, disk, result.Quota.DiskMb)
-	fmt.Print("GetQuota Result", result.String())
+	t.Run("TestRealisClient_GetQuota", func(t *testing.T) {
+		// Test GetQuota based on previously set values
+		var result *aurora.GetQuotaResult_
+		resp, err = r.GetQuota("vagrant")
+		if resp.GetResult_() != nil {
+			result = resp.GetResult_().GetQuotaResult_
+		}
+		assert.NoError(t, err)
+		assert.Equal(t, aurora.ResponseCode_OK, resp.ResponseCode)
+		for res := range result.Quota.GetResources() {
+			switch true {
+			case res.DiskMb != nil:
+				assert.Equal(t, disk, *res.DiskMb)
+				break
+			case res.NumCpus != nil:
+				assert.Equal(t, cpu, *res.NumCpus)
+				break
+			case res.RamMb != nil:
+				assert.Equal(t, ram, *res.RamMb)
+				break
+			}
+		}
+		fmt.Print("GetQuota Result", result.String())
+	})
 }

--- a/realis_e2e_test.go
+++ b/realis_e2e_test.go
@@ -389,3 +389,26 @@ func TestRealisClient_SessionThreadSafety(t *testing.T) {
 
 	wg.Wait()
 }
+
+// Test setting and getting the quota
+func TestRealisClient_SetQuota(t *testing.T) {
+	var cpu = 2.5
+	var ram int64 = 10240
+	var disk int64 = 10240
+	resp, err := r.SetQuota("vagrant", cpu, ram, disk)
+	assert.NoError(t, err)
+	assert.Equal(t, aurora.ResponseCode_OK, resp.ResponseCode)
+
+	// Test GetQuota based on previously set values
+	var result *aurora.GetQuotaResult_
+	resp, err = r.GetQuota("vagrant")
+	if resp.GetResult_() != nil {
+		result = resp.GetResult_().GetQuotaResult_
+	}
+	assert.NoError(t, err)
+	assert.Equal(t, aurora.ResponseCode_OK, resp.ResponseCode)
+	assert.Equal(t, cpu, result.Quota.NumCpus)
+	assert.Equal(t, ram, result.Quota.RamMb)
+	assert.Equal(t, disk, result.Quota.DiskMb)
+	fmt.Print("GetQuota Result", result.String())
+}

--- a/updatejob.go
+++ b/updatejob.go
@@ -138,7 +138,6 @@ func (u *UpdateJob) RollbackOnFail(rollback bool) *UpdateJob {
 	return u
 }
 
-
 func NewUpdateSettings() *aurora.JobUpdateSettings {
 
 	us := new(aurora.JobUpdateSettings)


### PR DESCRIPTION
This change set adds admin client calls to fetch and
mutate the OwnerRole quota[cpu,ram,disk].

-----------------------------------------
## Please read instructions below ##

Before submitting, please make sure you run a vagrant box running Aurora with the latest version shown in .auroraversion and run go test from the project root.

To run an Aurora Vagrant image, follow the instructions here:
http://aurora.apache.org/documentation/latest/getting-started/vagrant/

* Have you run goformat on the project before submitting? Yes

* Have you run go test on the project before submitting? Do all tests pass? Yes

* Does the Pull Request require a test to be added to the end to end tests? If so, has it been added? Yes and Yes