### PR TITLE
Task query optional parameters

### DIFF
--- a/auroraAPI.thrift
+++ b/auroraAPI.thrift
@@ -540,16 +540,16 @@ struct GetJobsResult {
  * (terms are AND'ed together).
  */
 struct TaskQuery {
-  14: string role
-  9: string environment
-  2: string jobName
-  4: set<string> taskIds
-  5: set<ScheduleStatus> statuses
-  7: set<i32> instanceIds
-  10: set<string> slaveHosts
-  11: set<JobKey> jobKeys
-  12: i32 offset
-  13: i32 limit
+  14: optional string role
+  9: optional string environment
+  2: optional string jobName
+  4: optional set<string> taskIds
+  5: optional set<ScheduleStatus> statuses
+  7: optional set<i32> instanceIds
+  10: optional set<string> slaveHosts
+  11: optional set<JobKey> jobKeys
+  12: optional i32 offset
+  13: optional i32 limit
 }
 
 struct HostStatus {

--- a/examples/client.go
+++ b/examples/client.go
@@ -553,9 +553,9 @@ func main() {
 	case "taskStatus":
 		fmt.Println("Getting task status")
 		taskQ := &aurora.TaskQuery{
-			Role:        job.JobKey().Role,
-			Environment: job.JobKey().Environment,
-			JobName:     job.JobKey().Name,
+			Role:        &job.JobKey().Role,
+			Environment: &job.JobKey().Environment,
+			JobName:     &job.JobKey().Name,
 		}
 		tasks, err := r.GetTaskStatus(taskQ)
 		if err != nil {
@@ -567,9 +567,9 @@ func main() {
 	case "tasksWithoutConfig":
 		fmt.Println("Getting task status")
 		taskQ := &aurora.TaskQuery{
-			Role:        job.JobKey().Role,
-			Environment: job.JobKey().Environment,
-			JobName:     job.JobKey().Name,
+			Role:        &job.JobKey().Role,
+			Environment: &job.JobKey().Environment,
+			JobName:     &job.JobKey().Name,
 		}
 		tasks, err := r.GetTasksWithoutConfigs(taskQ)
 		if err != nil {

--- a/gen-go/apache/aurora/ttypes.go
+++ b/gen-go/apache/aurora/ttypes.go
@@ -8020,64 +8020,139 @@ func (p *GetJobsResult_) String() string {
 //  - Limit
 type TaskQuery struct {
 	// unused field # 1
-	JobName string `thrift:"jobName,2" json:"jobName"`
+	JobName *string `thrift:"jobName,2" json:"jobName,omitempty"`
 	// unused field # 3
-	TaskIds  map[string]bool         `thrift:"taskIds,4" json:"taskIds"`
-	Statuses map[ScheduleStatus]bool `thrift:"statuses,5" json:"statuses"`
+	TaskIds  map[string]bool         `thrift:"taskIds,4" json:"taskIds,omitempty"`
+	Statuses map[ScheduleStatus]bool `thrift:"statuses,5" json:"statuses,omitempty"`
 	// unused field # 6
-	InstanceIds map[int32]bool `thrift:"instanceIds,7" json:"instanceIds"`
+	InstanceIds map[int32]bool `thrift:"instanceIds,7" json:"instanceIds,omitempty"`
 	// unused field # 8
-	Environment string           `thrift:"environment,9" json:"environment"`
-	SlaveHosts  map[string]bool  `thrift:"slaveHosts,10" json:"slaveHosts"`
-	JobKeys     map[*JobKey]bool `thrift:"jobKeys,11" json:"jobKeys"`
-	Offset      int32            `thrift:"offset,12" json:"offset"`
-	Limit       int32            `thrift:"limit,13" json:"limit"`
-	Role        string           `thrift:"role,14" json:"role"`
+	Environment *string          `thrift:"environment,9" json:"environment,omitempty"`
+	SlaveHosts  map[string]bool  `thrift:"slaveHosts,10" json:"slaveHosts,omitempty"`
+	JobKeys     map[*JobKey]bool `thrift:"jobKeys,11" json:"jobKeys,omitempty"`
+	Offset      *int32           `thrift:"offset,12" json:"offset,omitempty"`
+	Limit       *int32           `thrift:"limit,13" json:"limit,omitempty"`
+	Role        *string          `thrift:"role,14" json:"role,omitempty"`
 }
 
 func NewTaskQuery() *TaskQuery {
 	return &TaskQuery{}
 }
 
+var TaskQuery_Role_DEFAULT string
+
 func (p *TaskQuery) GetRole() string {
-	return p.Role
+	if !p.IsSetRole() {
+		return TaskQuery_Role_DEFAULT
+	}
+	return *p.Role
 }
+
+var TaskQuery_Environment_DEFAULT string
 
 func (p *TaskQuery) GetEnvironment() string {
-	return p.Environment
+	if !p.IsSetEnvironment() {
+		return TaskQuery_Environment_DEFAULT
+	}
+	return *p.Environment
 }
 
+var TaskQuery_JobName_DEFAULT string
+
 func (p *TaskQuery) GetJobName() string {
-	return p.JobName
+	if !p.IsSetJobName() {
+		return TaskQuery_JobName_DEFAULT
+	}
+	return *p.JobName
 }
+
+var TaskQuery_TaskIds_DEFAULT map[string]bool
 
 func (p *TaskQuery) GetTaskIds() map[string]bool {
 	return p.TaskIds
 }
 
+var TaskQuery_Statuses_DEFAULT map[ScheduleStatus]bool
+
 func (p *TaskQuery) GetStatuses() map[ScheduleStatus]bool {
 	return p.Statuses
 }
+
+var TaskQuery_InstanceIds_DEFAULT map[int32]bool
 
 func (p *TaskQuery) GetInstanceIds() map[int32]bool {
 	return p.InstanceIds
 }
 
+var TaskQuery_SlaveHosts_DEFAULT map[string]bool
+
 func (p *TaskQuery) GetSlaveHosts() map[string]bool {
 	return p.SlaveHosts
 }
+
+var TaskQuery_JobKeys_DEFAULT map[*JobKey]bool
 
 func (p *TaskQuery) GetJobKeys() map[*JobKey]bool {
 	return p.JobKeys
 }
 
+var TaskQuery_Offset_DEFAULT int32
+
 func (p *TaskQuery) GetOffset() int32 {
-	return p.Offset
+	if !p.IsSetOffset() {
+		return TaskQuery_Offset_DEFAULT
+	}
+	return *p.Offset
 }
 
+var TaskQuery_Limit_DEFAULT int32
+
 func (p *TaskQuery) GetLimit() int32 {
-	return p.Limit
+	if !p.IsSetLimit() {
+		return TaskQuery_Limit_DEFAULT
+	}
+	return *p.Limit
 }
+func (p *TaskQuery) IsSetRole() bool {
+	return p.Role != nil
+}
+
+func (p *TaskQuery) IsSetEnvironment() bool {
+	return p.Environment != nil
+}
+
+func (p *TaskQuery) IsSetJobName() bool {
+	return p.JobName != nil
+}
+
+func (p *TaskQuery) IsSetTaskIds() bool {
+	return p.TaskIds != nil
+}
+
+func (p *TaskQuery) IsSetStatuses() bool {
+	return p.Statuses != nil
+}
+
+func (p *TaskQuery) IsSetInstanceIds() bool {
+	return p.InstanceIds != nil
+}
+
+func (p *TaskQuery) IsSetSlaveHosts() bool {
+	return p.SlaveHosts != nil
+}
+
+func (p *TaskQuery) IsSetJobKeys() bool {
+	return p.JobKeys != nil
+}
+
+func (p *TaskQuery) IsSetOffset() bool {
+	return p.Offset != nil
+}
+
+func (p *TaskQuery) IsSetLimit() bool {
+	return p.Limit != nil
+}
+
 func (p *TaskQuery) Read(iprot thrift.TProtocol) error {
 	if _, err := iprot.ReadStructBegin(); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
@@ -8151,7 +8226,7 @@ func (p *TaskQuery) readField14(iprot thrift.TProtocol) error {
 	if v, err := iprot.ReadString(); err != nil {
 		return thrift.PrependError("error reading field 14: ", err)
 	} else {
-		p.Role = v
+		p.Role = &v
 	}
 	return nil
 }
@@ -8160,7 +8235,7 @@ func (p *TaskQuery) readField9(iprot thrift.TProtocol) error {
 	if v, err := iprot.ReadString(); err != nil {
 		return thrift.PrependError("error reading field 9: ", err)
 	} else {
-		p.Environment = v
+		p.Environment = &v
 	}
 	return nil
 }
@@ -8169,7 +8244,7 @@ func (p *TaskQuery) readField2(iprot thrift.TProtocol) error {
 	if v, err := iprot.ReadString(); err != nil {
 		return thrift.PrependError("error reading field 2: ", err)
 	} else {
-		p.JobName = v
+		p.JobName = &v
 	}
 	return nil
 }
@@ -8287,7 +8362,7 @@ func (p *TaskQuery) readField12(iprot thrift.TProtocol) error {
 	if v, err := iprot.ReadI32(); err != nil {
 		return thrift.PrependError("error reading field 12: ", err)
 	} else {
-		p.Offset = v
+		p.Offset = &v
 	}
 	return nil
 }
@@ -8296,7 +8371,7 @@ func (p *TaskQuery) readField13(iprot thrift.TProtocol) error {
 	if v, err := iprot.ReadI32(); err != nil {
 		return thrift.PrependError("error reading field 13: ", err)
 	} else {
-		p.Limit = v
+		p.Limit = &v
 	}
 	return nil
 }
@@ -8345,171 +8420,191 @@ func (p *TaskQuery) Write(oprot thrift.TProtocol) error {
 }
 
 func (p *TaskQuery) writeField2(oprot thrift.TProtocol) (err error) {
-	if err := oprot.WriteFieldBegin("jobName", thrift.STRING, 2); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field begin error 2:jobName: ", p), err)
-	}
-	if err := oprot.WriteString(string(p.JobName)); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T.jobName (2) field write error: ", p), err)
-	}
-	if err := oprot.WriteFieldEnd(); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field end error 2:jobName: ", p), err)
+	if p.IsSetJobName() {
+		if err := oprot.WriteFieldBegin("jobName", thrift.STRING, 2); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 2:jobName: ", p), err)
+		}
+		if err := oprot.WriteString(string(*p.JobName)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.jobName (2) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 2:jobName: ", p), err)
+		}
 	}
 	return err
 }
 
 func (p *TaskQuery) writeField4(oprot thrift.TProtocol) (err error) {
-	if err := oprot.WriteFieldBegin("taskIds", thrift.SET, 4); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field begin error 4:taskIds: ", p), err)
-	}
-	if err := oprot.WriteSetBegin(thrift.STRING, len(p.TaskIds)); err != nil {
-		return thrift.PrependError("error writing set begin: ", err)
-	}
-	for v, _ := range p.TaskIds {
-		if err := oprot.WriteString(string(v)); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
+	if p.IsSetTaskIds() {
+		if err := oprot.WriteFieldBegin("taskIds", thrift.SET, 4); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 4:taskIds: ", p), err)
 		}
-	}
-	if err := oprot.WriteSetEnd(); err != nil {
-		return thrift.PrependError("error writing set end: ", err)
-	}
-	if err := oprot.WriteFieldEnd(); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field end error 4:taskIds: ", p), err)
+		if err := oprot.WriteSetBegin(thrift.STRING, len(p.TaskIds)); err != nil {
+			return thrift.PrependError("error writing set begin: ", err)
+		}
+		for v, _ := range p.TaskIds {
+			if err := oprot.WriteString(string(v)); err != nil {
+				return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
+			}
+		}
+		if err := oprot.WriteSetEnd(); err != nil {
+			return thrift.PrependError("error writing set end: ", err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 4:taskIds: ", p), err)
+		}
 	}
 	return err
 }
 
 func (p *TaskQuery) writeField5(oprot thrift.TProtocol) (err error) {
-	if err := oprot.WriteFieldBegin("statuses", thrift.SET, 5); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field begin error 5:statuses: ", p), err)
-	}
-	if err := oprot.WriteSetBegin(thrift.I32, len(p.Statuses)); err != nil {
-		return thrift.PrependError("error writing set begin: ", err)
-	}
-	for v, _ := range p.Statuses {
-		if err := oprot.WriteI32(int32(v)); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
+	if p.IsSetStatuses() {
+		if err := oprot.WriteFieldBegin("statuses", thrift.SET, 5); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 5:statuses: ", p), err)
 		}
-	}
-	if err := oprot.WriteSetEnd(); err != nil {
-		return thrift.PrependError("error writing set end: ", err)
-	}
-	if err := oprot.WriteFieldEnd(); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field end error 5:statuses: ", p), err)
+		if err := oprot.WriteSetBegin(thrift.I32, len(p.Statuses)); err != nil {
+			return thrift.PrependError("error writing set begin: ", err)
+		}
+		for v, _ := range p.Statuses {
+			if err := oprot.WriteI32(int32(v)); err != nil {
+				return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
+			}
+		}
+		if err := oprot.WriteSetEnd(); err != nil {
+			return thrift.PrependError("error writing set end: ", err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 5:statuses: ", p), err)
+		}
 	}
 	return err
 }
 
 func (p *TaskQuery) writeField7(oprot thrift.TProtocol) (err error) {
-	if err := oprot.WriteFieldBegin("instanceIds", thrift.SET, 7); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field begin error 7:instanceIds: ", p), err)
-	}
-	if err := oprot.WriteSetBegin(thrift.I32, len(p.InstanceIds)); err != nil {
-		return thrift.PrependError("error writing set begin: ", err)
-	}
-	for v, _ := range p.InstanceIds {
-		if err := oprot.WriteI32(int32(v)); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
+	if p.IsSetInstanceIds() {
+		if err := oprot.WriteFieldBegin("instanceIds", thrift.SET, 7); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 7:instanceIds: ", p), err)
 		}
-	}
-	if err := oprot.WriteSetEnd(); err != nil {
-		return thrift.PrependError("error writing set end: ", err)
-	}
-	if err := oprot.WriteFieldEnd(); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field end error 7:instanceIds: ", p), err)
+		if err := oprot.WriteSetBegin(thrift.I32, len(p.InstanceIds)); err != nil {
+			return thrift.PrependError("error writing set begin: ", err)
+		}
+		for v, _ := range p.InstanceIds {
+			if err := oprot.WriteI32(int32(v)); err != nil {
+				return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
+			}
+		}
+		if err := oprot.WriteSetEnd(); err != nil {
+			return thrift.PrependError("error writing set end: ", err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 7:instanceIds: ", p), err)
+		}
 	}
 	return err
 }
 
 func (p *TaskQuery) writeField9(oprot thrift.TProtocol) (err error) {
-	if err := oprot.WriteFieldBegin("environment", thrift.STRING, 9); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field begin error 9:environment: ", p), err)
-	}
-	if err := oprot.WriteString(string(p.Environment)); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T.environment (9) field write error: ", p), err)
-	}
-	if err := oprot.WriteFieldEnd(); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field end error 9:environment: ", p), err)
+	if p.IsSetEnvironment() {
+		if err := oprot.WriteFieldBegin("environment", thrift.STRING, 9); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 9:environment: ", p), err)
+		}
+		if err := oprot.WriteString(string(*p.Environment)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.environment (9) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 9:environment: ", p), err)
+		}
 	}
 	return err
 }
 
 func (p *TaskQuery) writeField10(oprot thrift.TProtocol) (err error) {
-	if err := oprot.WriteFieldBegin("slaveHosts", thrift.SET, 10); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field begin error 10:slaveHosts: ", p), err)
-	}
-	if err := oprot.WriteSetBegin(thrift.STRING, len(p.SlaveHosts)); err != nil {
-		return thrift.PrependError("error writing set begin: ", err)
-	}
-	for v, _ := range p.SlaveHosts {
-		if err := oprot.WriteString(string(v)); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
+	if p.IsSetSlaveHosts() {
+		if err := oprot.WriteFieldBegin("slaveHosts", thrift.SET, 10); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 10:slaveHosts: ", p), err)
 		}
-	}
-	if err := oprot.WriteSetEnd(); err != nil {
-		return thrift.PrependError("error writing set end: ", err)
-	}
-	if err := oprot.WriteFieldEnd(); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field end error 10:slaveHosts: ", p), err)
+		if err := oprot.WriteSetBegin(thrift.STRING, len(p.SlaveHosts)); err != nil {
+			return thrift.PrependError("error writing set begin: ", err)
+		}
+		for v, _ := range p.SlaveHosts {
+			if err := oprot.WriteString(string(v)); err != nil {
+				return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
+			}
+		}
+		if err := oprot.WriteSetEnd(); err != nil {
+			return thrift.PrependError("error writing set end: ", err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 10:slaveHosts: ", p), err)
+		}
 	}
 	return err
 }
 
 func (p *TaskQuery) writeField11(oprot thrift.TProtocol) (err error) {
-	if err := oprot.WriteFieldBegin("jobKeys", thrift.SET, 11); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field begin error 11:jobKeys: ", p), err)
-	}
-	if err := oprot.WriteSetBegin(thrift.STRUCT, len(p.JobKeys)); err != nil {
-		return thrift.PrependError("error writing set begin: ", err)
-	}
-	for v, _ := range p.JobKeys {
-		if err := v.Write(oprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", v), err)
+	if p.IsSetJobKeys() {
+		if err := oprot.WriteFieldBegin("jobKeys", thrift.SET, 11); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 11:jobKeys: ", p), err)
 		}
-	}
-	if err := oprot.WriteSetEnd(); err != nil {
-		return thrift.PrependError("error writing set end: ", err)
-	}
-	if err := oprot.WriteFieldEnd(); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field end error 11:jobKeys: ", p), err)
+		if err := oprot.WriteSetBegin(thrift.STRUCT, len(p.JobKeys)); err != nil {
+			return thrift.PrependError("error writing set begin: ", err)
+		}
+		for v, _ := range p.JobKeys {
+			if err := v.Write(oprot); err != nil {
+				return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", v), err)
+			}
+		}
+		if err := oprot.WriteSetEnd(); err != nil {
+			return thrift.PrependError("error writing set end: ", err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 11:jobKeys: ", p), err)
+		}
 	}
 	return err
 }
 
 func (p *TaskQuery) writeField12(oprot thrift.TProtocol) (err error) {
-	if err := oprot.WriteFieldBegin("offset", thrift.I32, 12); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field begin error 12:offset: ", p), err)
-	}
-	if err := oprot.WriteI32(int32(p.Offset)); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T.offset (12) field write error: ", p), err)
-	}
-	if err := oprot.WriteFieldEnd(); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field end error 12:offset: ", p), err)
+	if p.IsSetOffset() {
+		if err := oprot.WriteFieldBegin("offset", thrift.I32, 12); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 12:offset: ", p), err)
+		}
+		if err := oprot.WriteI32(int32(*p.Offset)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.offset (12) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 12:offset: ", p), err)
+		}
 	}
 	return err
 }
 
 func (p *TaskQuery) writeField13(oprot thrift.TProtocol) (err error) {
-	if err := oprot.WriteFieldBegin("limit", thrift.I32, 13); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field begin error 13:limit: ", p), err)
-	}
-	if err := oprot.WriteI32(int32(p.Limit)); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T.limit (13) field write error: ", p), err)
-	}
-	if err := oprot.WriteFieldEnd(); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field end error 13:limit: ", p), err)
+	if p.IsSetLimit() {
+		if err := oprot.WriteFieldBegin("limit", thrift.I32, 13); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 13:limit: ", p), err)
+		}
+		if err := oprot.WriteI32(int32(*p.Limit)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.limit (13) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 13:limit: ", p), err)
+		}
 	}
 	return err
 }
 
 func (p *TaskQuery) writeField14(oprot thrift.TProtocol) (err error) {
-	if err := oprot.WriteFieldBegin("role", thrift.STRING, 14); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field begin error 14:role: ", p), err)
-	}
-	if err := oprot.WriteString(string(p.Role)); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T.role (14) field write error: ", p), err)
-	}
-	if err := oprot.WriteFieldEnd(); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field end error 14:role: ", p), err)
+	if p.IsSetRole() {
+		if err := oprot.WriteFieldBegin("role", thrift.STRING, 14); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 14:role: ", p), err)
+		}
+		if err := oprot.WriteString(string(*p.Role)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.role (14) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 14:role: ", p), err)
+		}
 	}
 	return err
 }

--- a/realis.go
+++ b/realis.go
@@ -497,9 +497,9 @@ func (r *realisClient) Close() {
 // Uses predefined set of states to retrieve a set of active jobs in Apache Aurora.
 func (r *realisClient) GetInstanceIds(key *aurora.JobKey, states map[aurora.ScheduleStatus]bool) (map[int32]bool, error) {
 	taskQ := &aurora.TaskQuery{
-		Role:        key.Role,
-		Environment: key.Environment,
-		JobName:     key.Name,
+		Role:        &key.Role,
+		Environment: &key.Environment,
+		JobName:     &key.Name,
 		Statuses:    states,
 	}
 
@@ -880,9 +880,9 @@ func (r *realisClient) FetchTaskConfig(instKey aurora.InstanceKey) (*aurora.Task
 
 	ids[instKey.InstanceId] = true
 	taskQ := &aurora.TaskQuery{
-		Role:        instKey.JobKey.Role,
-		Environment: instKey.JobKey.Environment,
-		JobName:     instKey.JobKey.Name,
+		Role:        &instKey.JobKey.Role,
+		Environment: &instKey.JobKey.Environment,
+		JobName:     &instKey.JobKey.Name,
 		InstanceIds: ids,
 		Statuses:    aurora.ACTIVE_STATES,
 	}

--- a/realis_e2e_test.go
+++ b/realis_e2e_test.go
@@ -75,11 +75,7 @@ func TestNonExistentEndpoint(t *testing.T) {
 	)
 	defer r.Close()
 
-	taskQ := &aurora.TaskQuery{
-		Role:        "no",
-		Environment: "task",
-		JobName:     "here",
-	}
+	taskQ := &aurora.TaskQuery{}
 
 	_, err = r.GetTasksWithoutConfigs(taskQ)
 


### PR DESCRIPTION
# Summary
* API Thift was changed to make parameters in TaskQuery struct optional
* Thrift autogenerated code was regenerated
* Files where TaskQuery was being used in the project were changed to use the new TaskQuery struct
* Tests were succesfully executed in Aurora vagrant

**Test Run**
```
root@843d23b9440d:/go/src/github.com/paypal/gorealis# go test
realis: 2018/06/27 21:25:28 Scheduler URL:  http://192.168.33.7:8081
realis: 2018/06/27 21:25:28 gorealis config url: http://192.168.33.7:8081
realis: 2018/06/27 21:25:28 Scheduler URL:  http://127.0.0.1:8081/doesntexist/
realis: 2018/06/27 21:25:28 gorealis config url: http://127.0.0.1:8081/doesntexist/
realis: 2018/06/27 21:25:28 Client Error: Post http://127.0.0.1:8081/doesntexist//api: dial tcp 127.0.0.1:8081: connect: connection refused
realis: 2018/06/27 21:25:28 Re-establishing Connection to Aurora
realis: 2018/06/27 21:25:28 Scheduler URL:  http://127.0.0.1:8081/doesntexist/
realis: 2018/06/27 21:25:28 gorealis config url: http://127.0.0.1:8081/doesntexist/
realis: 2018/06/27 21:25:28 A retriable error occurred during thrift call, backing off for 1.08886628s before retry 1
realis: 2018/06/27 21:25:29 Client Error: Post http://127.0.0.1:8081/doesntexist//api: dial tcp 127.0.0.1:8081: connect: connection refused
realis: 2018/06/27 21:25:29 Re-establishing Connection to Aurora
realis: 2018/06/27 21:25:29 Scheduler URL:  http://127.0.0.1:8081/doesntexist/
realis: 2018/06/27 21:25:29 gorealis config url: http://127.0.0.1:8081/doesntexist/
realis: 2018/06/27 21:25:29 A retriable error occurred during thrift call, backing off for 1.073552716s before retry 2
realis: 2018/06/27 21:25:31 Client Error: Post http://127.0.0.1:8081/doesntexist//api: dial tcp 127.0.0.1:8081: connect: connection refused
realis: 2018/06/27 21:25:31 Re-establishing Connection to Aurora
realis: 2018/06/27 21:25:31 Scheduler URL:  http://127.0.0.1:8081/doesntexist/
realis: 2018/06/27 21:25:31 gorealis config url: http://127.0.0.1:8081/doesntexist/
realis: 2018/06/27 21:25:31 A retriable error occurred during thrift call, backing off for 1.029528335s before retry 3
realis: 2018/06/27 21:25:32 Client Error: Post http://127.0.0.1:8081/doesntexist//api: dial tcp 127.0.0.1:8081: connect: connection refused
realis: 2018/06/27 21:25:32 Re-establishing Connection to Aurora
realis: 2018/06/27 21:25:32 Scheduler URL:  http://127.0.0.1:8081/doesntexist/
realis: 2018/06/27 21:25:32 gorealis config url: http://127.0.0.1:8081/doesntexist/
realis: 2018/06/27 21:25:32 A retriable error occurred during thrift call, backing off for 1.037047965s before retry 4
realis: 2018/06/27 21:25:33 Client Error: Post http://127.0.0.1:8081/doesntexist//api: dial tcp 127.0.0.1:8081: connect: connection refused
realis: 2018/06/27 21:25:33 Re-establishing Connection to Aurora
realis: 2018/06/27 21:25:33 Scheduler URL:  http://127.0.0.1:8081/doesntexist/
realis: 2018/06/27 21:25:33 gorealis config url: http://127.0.0.1:8081/doesntexist/
realis: 2018/06/27 21:25:33 retried this thrift call 5 time(s)
realis: 2018/06/27 21:25:33 Re-establishing Connection to Aurora
realis: 2018/06/27 21:25:33 Scheduler URL:  http://192.168.33.7:8081
realis: 2018/06/27 21:25:33 gorealis config url: http://192.168.33.7:8081
Create call took 12617457 ns
GetJobs length: 1
Kill call took 15427808 ns
Creating service
StartJobUpdateResult_({Key:JobUpdateKey({Job:JobKey({Role:vagrant Environment:prod Name:create_thermos_job_test}) ID:be7fb47c-7911-440e-910b-194e3d2d154f}) UpdateSummary:JobUpdateSummary({User:aurora State:<nil> Key:JobUpdateKey({Job:JobKey({Role:vagrant Environment:prod Name:create_thermos_job_test}) ID:be7fb47c-7911-440e-910b-194e3d2d154f}) Metadata:map[]})})
sending PulseJobUpdate....
Polling, update still active...
sending PulseJobUpdate....
Polling, update still active...
sending PulseJobUpdate....
realis: 2018/06/27 21:26:35 Client Error: Post http://192.168.33.7:8081/api: EOF
realis: 2018/06/27 21:26:35 Re-establishing Connection to Aurora
realis: 2018/06/27 21:26:35 Scheduler URL:  http://192.168.33.7:8081
realis: 2018/06/27 21:26:35 gorealis config url: http://192.168.33.7:8081
realis: 2018/06/27 21:26:35 A retriable error occurred during thrift call, backing off for 10.786922507s before retry 1
Polling, update still active...
sending PulseJobUpdate....
realis: 2018/06/27 21:27:16 Client Error: Post http://192.168.33.7:8081/api: EOF
realis: 2018/06/27 21:27:16 Re-establishing Connection to Aurora
realis: 2018/06/27 21:27:16 Scheduler URL:  http://192.168.33.7:8081
realis: 2018/06/27 21:27:16 gorealis config url: http://192.168.33.7:8081
realis: 2018/06/27 21:27:16 A retriable error occurred during thrift call, backing off for 10.693648452s before retry 1
Update succeded
Update call took 111549606973 ns
Kill call took 15376085 ns
Schedule cron call took 11627707 ns
Deschedule cron call took 25486842 ns
GetQuota ResultGetQuotaResult_({Quota:ResourceAggregate({NumCpus:3.5 RamMb:20480 DiskMb:10240 Resources:map[Resource({NumCpus:0xc420087cb0 RamMb:<nil> DiskMb:<nil> NamedPort:<nil> NumGpus:<nil>}):true Resource({NumCpus:<nil> RamMb:<nil> DiskMb:0xc420087cd8 NamedPort:<nil> NumGpus:<nil>}):true Resource({NumCpus:<nil> RamMb:0xc420087d08 DiskMb:<nil> NamedPort:<nil> NumGpus:<nil>}):true]}) ProdSharedConsumption:ResourceAggregate({NumCpus:0 RamMb:0 DiskMb:0 Resources:map[Resource({NumCpus:0xc420087dd8 RamMb:<nil> DiskMb:<nil> NamedPort:<nil> NumGpus:<nil>}):true Resource({NumCpus:<nil> RamMb:<nil> DiskMb:0xc420087e00 NamedPort:<nil> NumGpus:<nil>}):true Resource({NumCpus:<nil> RamMb:0xc420087e28 DiskMb:<nil> NamedPort:<nil> NumGpus:<nil>}):true]}) NonProdSharedConsumption:ResourceAggregate({NumCpus:1.75 RamMb:28 DiskMb:70 Resources:map[Resource({NumCpus:<nil> RamMb:<nil> DiskMb:0xc420087f00 NamedPort:<nil> NumGpus:<nil>}):true Resource({NumCpus:<nil> RamMb:0xc420087f28 DiskMb:<nil> NamedPort:<nil> NumGpus:<nil>}):true Resource({NumCpus:0xc420087f50 RamMb:<nil> DiskMb:<nil> NamedPort:<nil> NumGpus:<nil>}):true]}) ProdDedicatedConsumption:ResourceAggregate({NumCpus:0 RamMb:0 DiskMb:0 Resources:map[Resource({NumCpus:0xc42054e020 RamMb:<nil> DiskMb:<nil> NamedPort:<nil> NumGpus:<nil>}):true Resource({NumCpus:<nil> RamMb:<nil> DiskMb:0xc42054e048 NamedPort:<nil> NumGpus:<nil>}):true Resource({NumCpus:<nil> RamMb:0xc42054e070 DiskMb:<nil> NamedPort:<nil> NumGpus:<nil>}):true]}) NonProdDedicatedConsumption:ResourceAggregate({NumCpus:0 RamMb:0 DiskMb:0 Resources:map[Resource({NumCpus:0xc42054e138 RamMb:<nil> DiskMb:<nil> NamedPort:<nil> NumGpus:<nil>}):true Resource({NumCpus:<nil> RamMb:<nil> DiskMb:0xc42054e160 NamedPort:<nil> NumGpus:<nil>}):true Resource({NumCpus:<nil> RamMb:0xc42054e188 DiskMb:<nil> NamedPort:<nil> NumGpus:<nil>}):true]})})realis-debug: 2018/06/27 Failed to connect to 127.0.0.1:2181: dial tcp 127.0.0.1:2181: connect: connection refused
realis-debug: 2018/06/27 Path /somepath doesn't exist on Zookeeper : zk: could not connect to a server
realis-debug: 2018/06/27 A retriable error occurred during function call, backing off for 1.025826557s before retrying
realis-debug: 2018/06/27 Failed to connect to 127.0.0.1:2181: dial tcp 127.0.0.1:2181: connect: connection refused
realis-debug: 2018/06/27 Path /somepath doesn't exist on Zookeeper : zk: could not connect to a server
realis-debug: 2018/06/27 A retriable error occurred during function call, backing off for 1.013525409s before retrying
realis-debug: 2018/06/27 Failed to connect to 127.0.0.1:2181: dial tcp 127.0.0.1:2181: connect: connection refused
realis-debug: 2018/06/27 Path /somepath doesn't exist on Zookeeper : zk: could not connect to a server
realis-debug: 2018/06/27 A retriable error occurred during function call, backing off for 1.094830465s before retrying
realis-debug: 2018/06/27 Failed to connect to 127.0.0.1:2181: dial tcp 127.0.0.1:2181: connect: connection refused
realis-debug: 2018/06/27 Path /somepath doesn't exist on Zookeeper : zk: could not connect to a server
realis-debug: 2018/06/27 A retriable error occurred during function call, backing off for 1.027652476s before retrying
realis-debug: 2018/06/27 Failed to connect to 127.0.0.1:2181: dial tcp 127.0.0.1:2181: connect: connection refused
realis-debug: 2018/06/27 Path /somepath doesn't exist on Zookeeper : zk: could not connect to a server
realis-debug: 2018/06/27 retried this function call 5 time(s)
realis-debug: 2018/06/27 Failed to determine leader after 5 attempts
realis-debug: 2018/06/27 Failed to connect to 127.0.0.1:2181: dial tcp 127.0.0.1:2181: connect: connection refused
realis-debug: 2018/06/27 Failed to determine leader after 5 attempts
PASS
ok  	github.com/paypal/gorealis	159.911s
```