### PR TITLE
Adds support for Tier and SlaPolicy to the Job interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - docker-compose up -d
 
 script:
-  - go test -race -coverprofile=coverage.txt -covermode=atomic -v github.com/paypal/gorealis
+  - go test -race -coverprofile=coverage.txt -covermode=atomic -v github.com/paypal/gorealis -timeout 15m
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,74 @@ services:
     depends_on:
     - zk
 
+  agent-two:
+    image: rdelvalle/mesos-agent:1.5.1
+    pid: host
+    restart: on-failure
+    environment:
+      MESOS_MASTER: zk://192.168.33.2:2181/mesos
+      MESOS_CONTAINERIZERS: docker,mesos
+      MESOS_PORT: 5051
+      MESOS_HOSTNAME: localhost
+      MESOS_RESOURCES: ports(*):[11000-11999]
+      MESOS_SYSTEMD_ENABLE_SUPPORT: 'false'
+      MESOS_WORK_DIR: /tmp/mesos
+    networks:
+      aurora_cluster:
+        ipv4_address: 192.168.33.5
+
+    volumes:
+    - /sys/fs/cgroup:/sys/fs/cgroup
+    - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+    - zk
+
+
+  agent-three:
+    image: rdelvalle/mesos-agent:1.5.1
+    pid: host
+    restart: on-failure
+    environment:
+      MESOS_MASTER: zk://192.168.33.2:2181/mesos
+      MESOS_CONTAINERIZERS: docker,mesos
+      MESOS_PORT: 5051
+      MESOS_HOSTNAME: localhost
+      MESOS_RESOURCES: ports(*):[11000-11999]
+      MESOS_SYSTEMD_ENABLE_SUPPORT: 'false'
+      MESOS_WORK_DIR: /tmp/mesos
+    networks:
+      aurora_cluster:
+        ipv4_address: 192.168.33.16
+
+    volumes:
+    - /sys/fs/cgroup:/sys/fs/cgroup
+    - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+    - zk
+
+
+  agent-four:
+    image: rdelvalle/mesos-agent:1.5.1
+    pid: host
+    restart: on-failure
+    environment:
+      MESOS_MASTER: zk://192.168.33.2:2181/mesos
+      MESOS_CONTAINERIZERS: docker,mesos
+      MESOS_PORT: 5051
+      MESOS_HOSTNAME: localhost
+      MESOS_RESOURCES: ports(*):[11000-11999]
+      MESOS_SYSTEMD_ENABLE_SUPPORT: 'false'
+      MESOS_WORK_DIR: /tmp/mesos
+    networks:
+      aurora_cluster:
+        ipv4_address: 192.168.33.15
+
+    volumes:
+    - /sys/fs/cgroup:/sys/fs/cgroup
+    - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+    - zk
+
   aurora-one:
     image: rdelvalle/aurora:0.21.0
     pid: host

--- a/job.go
+++ b/job.go
@@ -56,7 +56,7 @@ type Job interface {
 	MaxFailure(maxFail int32) Job
 	Container(container Container) Job
 	PartitionPolicy(policy *aurora.PartitionPolicy) Job
-	Tier(tier *string) Job
+	Tier(tier string) Job
 	SlaPolicy(policy *aurora.SlaPolicy) Job
 }
 
@@ -326,8 +326,8 @@ func (j *AuroraJob) PartitionPolicy(policy *aurora.PartitionPolicy) Job {
 }
 
 // Set the Tier for the Job.
-func (j *AuroraJob) Tier(tier *string) Job {
-	j.jobConfig.TaskConfig.Tier = tier
+func (j *AuroraJob) Tier(tier string) Job {
+	j.jobConfig.TaskConfig.Tier = &tier
 
 	return j
 }

--- a/job.go
+++ b/job.go
@@ -56,6 +56,8 @@ type Job interface {
 	MaxFailure(maxFail int32) Job
 	Container(container Container) Job
 	PartitionPolicy(policy *aurora.PartitionPolicy) Job
+	Tier(tier *string) Job
+	SlaPolicy(policy *aurora.SlaPolicy) Job
 }
 
 // Structure to collect all information pertaining to an Aurora job.
@@ -320,6 +322,19 @@ func (j *AuroraJob) Container(container Container) Job {
 // Set a partition policy for the job configuration to implement.
 func (j *AuroraJob) PartitionPolicy(policy *aurora.PartitionPolicy) Job {
 	j.jobConfig.TaskConfig.PartitionPolicy = policy
+	return j
+}
+
+// Set the Tier for the Job.
+func (j *AuroraJob) Tier(tier *string) Job {
+	j.jobConfig.TaskConfig.Tier = tier
+
+	return j
+}
+
+// Set an SlaPolicy for the Job.
+func (j *AuroraJob) SlaPolicy(policy *aurora.SlaPolicy) Job {
+	j.jobConfig.TaskConfig.SlaPolicy = policy
 
 	return j
 }

--- a/runTestsMac.sh
+++ b/runTestsMac.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Since we run our docker compose setup in bridge mode to be able to run on MacOS, we have to launch a Docker container within the bridge network in order to avoid any routing issues.
-docker run -t -v $(pwd):/go/src/github.com/paypal/gorealis --network gorealis_aurora_cluster golang:1.10.3-stretch  go test -v github.com/paypal/gorealis
+docker run -t -v $(pwd):/go/src/github.com/paypal/gorealis --network gorealis_aurora_cluster golang:1.10.3-stretch  go test -v github.com/paypal/gorealis -timeout 15m


### PR DESCRIPTION
This adds the following function to the Job interface
- `Tier(tier *string) Job`
- `SlaPolicy(policy *aurora.SlaPolicy) Job`
- Test coverage for each in the end to end tests.