### PR TITLE
Trace level for logger

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -44,36 +44,36 @@ func (l *LevelLogger) EnableTrace(enable bool) {
 
 func (l LevelLogger) DebugPrintf(format string, a ...interface{}) {
 	if l.debug {
-		l.Printf("[DEBUG] " + format, a...)
+		l.Printf("[DEBUG] "+format, a...)
 	}
 }
 
 func (l LevelLogger) DebugPrint(a ...interface{}) {
 	if l.debug {
-		l.Print(append([]interface{}{"[DEBUG] "}, a))
+		l.Print(append([]interface{}{"[DEBUG] "}, a)...)
 	}
 }
 
 func (l LevelLogger) DebugPrintln(a ...interface{}) {
 	if l.debug {
-		l.Println(append([]interface{}{"[DEBUG] "}, a))
+		l.Println(append([]interface{}{"[DEBUG] "}, a)...)
 	}
 }
 
 func (l LevelLogger) TracePrintf(format string, a ...interface{}) {
 	if l.trace {
-		l.Printf("[TRACE] " + format, a...)
+		l.Printf("[TRACE] "+format, a...)
 	}
 }
 
 func (l LevelLogger) TracePrint(a ...interface{}) {
 	if l.trace {
-		l.Print(append([]interface{}{"[TRACE] "}, a))
+		l.Print(append([]interface{}{"[TRACE] "}, a)...)
 	}
 }
 
 func (l LevelLogger) TracePrintln(a ...interface{}) {
 	if l.trace {
-		l.Println(append([]interface{}{"[TRACE] "}, a))
+		l.Println(append([]interface{}{"[TRACE] "}, a)...)
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -31,6 +31,7 @@ func (NoopLogger) Println(a ...interface{}) {}
 type LevelLogger struct {
 	Logger
 	debug bool
+	trace bool
 }
 
 func (l *LevelLogger) EnableDebug(enable bool) {
@@ -40,6 +41,13 @@ func (l *LevelLogger) EnableDebug(enable bool) {
 func (l LevelLogger) DebugPrintf(format string, a ...interface{}) {
 	if l.debug {
 		l.Print("[DEBUG] ")
+		l.Printf(format, a...)
+	}
+}
+
+func (l LevelLogger) TracePrintf(format string, a ...interface{}) {
+	if l.debug {
+		l.Print("[TRACE] ")
 		l.Printf(format, a...)
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -38,30 +38,42 @@ func (l *LevelLogger) EnableDebug(enable bool) {
 	l.debug = enable
 }
 
-func (l LevelLogger) DebugPrintf(format string, a ...interface{}) {
-	if l.debug {
-		l.Print("[DEBUG] ")
-		l.Printf(format, a...)
-	}
+func (l *LevelLogger) EnableTrace(enable bool) {
+	l.trace = enable
 }
 
-func (l LevelLogger) TracePrintf(format string, a ...interface{}) {
+func (l LevelLogger) DebugPrintf(format string, a ...interface{}) {
 	if l.debug {
-		l.Print("[TRACE] ")
-		l.Printf(format, a...)
+		l.Printf("[DEBUG] " + format, a...)
 	}
 }
 
 func (l LevelLogger) DebugPrint(a ...interface{}) {
 	if l.debug {
-		l.Print("[DEBUG] ")
-		l.Print(a...)
+		l.Print(append([]interface{}{"[DEBUG] "}, a))
 	}
 }
 
 func (l LevelLogger) DebugPrintln(a ...interface{}) {
 	if l.debug {
-		l.Print("[DEBUG] ")
-		l.Println(a...)
+		l.Println(append([]interface{}{"[DEBUG] "}, a))
+	}
+}
+
+func (l LevelLogger) TracePrintf(format string, a ...interface{}) {
+	if l.trace {
+		l.Printf("[TRACE] " + format, a...)
+	}
+}
+
+func (l LevelLogger) TracePrint(a ...interface{}) {
+	if l.trace {
+		l.Print(append([]interface{}{"[TRACE] "}, a))
+	}
+}
+
+func (l LevelLogger) TracePrintln(a ...interface{}) {
+	if l.trace {
+		l.Println(append([]interface{}{"[TRACE] "}, a))
 	}
 }

--- a/realis.go
+++ b/realis.go
@@ -270,7 +270,11 @@ func NewRealisClient(options ...ClientOption) (Realis, error) {
 	// Default configs
 	config.timeoutms = 10000
 	config.backoff = defaultBackoff
-	config.logger = &LevelLogger{log.New(os.Stdout, "realis: ", log.Ltime|log.Ldate|log.LUTC), false, false}
+	config.logger = &LevelLogger{
+		Logger: log.New(os.Stdout, "realis: ", log.Ltime|log.Ldate|log.LUTC),
+		debug: false,
+		trace: false,
+	}
 
 	// Save options to recreate client if a connection error happens
 	config.options = options
@@ -284,12 +288,16 @@ func NewRealisClient(options ...ClientOption) (Realis, error) {
 
 	// Turn off all logging (including debug)
 	if config.logger == nil {
-		config.logger = &LevelLogger{NoopLogger{}, false, false}
+		config.logger = &LevelLogger{Logger: NoopLogger{}, debug: false, trace: false}
 	}
 
 	// Set a logger if debug has been set to true but no logger has been set
 	if config.logger == nil && config.debug {
-		config.logger = &LevelLogger{log.New(os.Stdout, "realis: ", log.Ltime|log.Ldate|log.LUTC), true, false}
+		config.logger = &LevelLogger{
+			Logger: log.New(os.Stdout, "realis: ", log.Ltime|log.Ldate|log.LUTC),
+			debug: true,
+			trace: false,
+		}
 	}
 
 	config.logger.debug = config.debug
@@ -361,7 +369,7 @@ func NewRealisClient(options ...ClientOption) (Realis, error) {
 		client:         aurora.NewAuroraSchedulerManagerClientFactory(config.transport, config.protoFactory),
 		readonlyClient: aurora.NewReadOnlySchedulerClientFactory(config.transport, config.protoFactory),
 		adminClient:    aurora.NewAuroraAdminClientFactory(config.transport, config.protoFactory),
-		logger:         LevelLogger{config.logger, config.debug, config.trace},
+		logger:         LevelLogger{Logger: config.logger, debug: config.debug, trace: config.trace},
 		lock:           &sync.Mutex{}}, nil
 }
 

--- a/realis.go
+++ b/realis.go
@@ -217,7 +217,7 @@ func ZookeeperOptions(opts ...ZKOpt) ClientOption {
 // Using the word set to avoid name collision with Interface.
 func SetLogger(l Logger) ClientOption {
 	return func(config *RealisConfig) {
-		config.logger = &LevelLogger{l, false, false}
+		config.logger = &LevelLogger{Logger: l}
 	}
 }
 
@@ -270,11 +270,7 @@ func NewRealisClient(options ...ClientOption) (Realis, error) {
 	// Default configs
 	config.timeoutms = 10000
 	config.backoff = defaultBackoff
-	config.logger = &LevelLogger{
-		Logger: log.New(os.Stdout, "realis: ", log.Ltime|log.Ldate|log.LUTC),
-		debug: false,
-		trace: false,
-	}
+	config.logger = &LevelLogger{Logger: log.New(os.Stdout, "realis: ", log.Ltime|log.Ldate|log.LUTC)}
 
 	// Save options to recreate client if a connection error happens
 	config.options = options
@@ -288,7 +284,7 @@ func NewRealisClient(options ...ClientOption) (Realis, error) {
 
 	// Turn off all logging (including debug)
 	if config.logger == nil {
-		config.logger = &LevelLogger{Logger: NoopLogger{}, debug: false, trace: false}
+		config.logger = &LevelLogger{Logger: NoopLogger{}}
 	}
 
 	// Set a logger if debug has been set to true but no logger has been set
@@ -296,7 +292,6 @@ func NewRealisClient(options ...ClientOption) (Realis, error) {
 		config.logger = &LevelLogger{
 			Logger: log.New(os.Stdout, "realis: ", log.Ltime|log.Ldate|log.LUTC),
 			debug: true,
-			trace: false,
 		}
 	}
 
@@ -305,6 +300,7 @@ func NewRealisClient(options ...ClientOption) (Realis, error) {
 
 	// Note, by this point, a LevelLogger should have been created.
 	config.logger.EnableDebug(config.debug)
+	config.logger.EnableTrace(config.trace)
 
 	config.logger.DebugPrintln("Number of options applied to config: ", len(options))
 

--- a/realis.go
+++ b/realis.go
@@ -291,7 +291,7 @@ func NewRealisClient(options ...ClientOption) (Realis, error) {
 	if config.logger == nil && config.debug {
 		config.logger = &LevelLogger{
 			Logger: log.New(os.Stdout, "realis: ", log.Ltime|log.Ldate|log.LUTC),
-			debug: true,
+			debug:  true,
 		}
 	}
 

--- a/retry.go
+++ b/retry.go
@@ -148,7 +148,7 @@ func (r *realisClient) thriftCallWithRetries(thriftCall auroraThriftCall) (*auro
 
 			resp, clientErr = thriftCall()
 
-			r.logger.DebugPrintf("Aurora Thrift Call ended resp: %v clientErr: %v\n", resp, clientErr)
+			r.logger.TracePrintf("Aurora Thrift Call ended resp: %v clientErr: %v\n", resp, clientErr)
 		}()
 
 		// Check if our thrift call is returning an error. This is a retriable event as we don't know


### PR DESCRIPTION
Add trace level to print out response thrift objects. 

This allows user to control weather these are printed or not to avoid pollution and addresses #76 