### PR TITLE
Making abort job synchronous

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -28,6 +28,19 @@ func IsTimeout(err error) bool {
 	return ok && temp.Timedout()
 }
 
+type timeoutErr struct {
+	error
+	timedout bool
+}
+
+func (r *timeoutErr) Timedout() bool {
+	return r.timedout
+}
+
+func newTimedoutError(err error) *timeoutErr {
+	return &timeoutErr{error: err, timedout: true}
+}
+
 // retryErr is a superset of timeout which includes extra context
 // with regards to our retry mechanism. This is done in order to make sure
 // that our retry mechanism works as expected through our tests and should

--- a/monitors.go
+++ b/monitors.go
@@ -35,54 +35,73 @@ type Monitor struct {
 
 // Polls the scheduler every certain amount of time to see if the update has succeeded
 func (m *Monitor) JobUpdate(updateKey aurora.JobUpdateKey, interval int, timeout int) (bool, error) {
+	status, err := m.JobUpdateStatus(updateKey,
+		map[aurora.JobUpdateStatus]bool{
+			aurora.JobUpdateStatus_ROLLED_FORWARD: true,
+			aurora.JobUpdateStatus_ROLLED_BACK: true,
+			aurora.JobUpdateStatus_ABORTED: true,
+			aurora.JobUpdateStatus_ERROR: true,
+			aurora.JobUpdateStatus_FAILED: true,
+		},
+		time.Duration(interval) * time.Second,
+		time.Duration(timeout) * time.Second)
+
+	if err != nil {
+		return false, err
+	}
+
+	// Rolled forward is the only state in which an update has been successfully updated
+	// if we encounter an inactive state and it is not at rolled forward, update failed
+	switch status {
+	case aurora.JobUpdateStatus_ROLLED_FORWARD:
+		m.Client.RealisConfig().logger.Println("Update succeeded")
+		return true, nil
+	case aurora.JobUpdateStatus_FAILED:
+		m.Client.RealisConfig().logger.Println("Update failed")
+		return false, errors.New(UpdateFailed)
+	case aurora.JobUpdateStatus_ROLLED_BACK:
+		m.Client.RealisConfig().logger.Println("rolled back")
+		return false, errors.New(RolledBack)
+	default:
+		return false, nil
+	}
+}
+
+func (m *Monitor) JobUpdateStatus(updateKey aurora.JobUpdateKey, desiredStatuses map[aurora.JobUpdateStatus]bool, interval, timeout time.Duration) (aurora.JobUpdateStatus, error) {
 
 	updateQ := aurora.JobUpdateQuery{
 		Key:   &updateKey,
 		Limit: 1,
 	}
-	ticker := time.NewTicker(time.Second * time.Duration(interval))
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
-	timer := time.NewTimer(time.Second * time.Duration(timeout))
+	timer := time.NewTimer(timeout)
 	defer timer.Stop()
+
 	var cliErr error
 	var respDetail *aurora.Response
-
 	for {
 		select {
 		case <-ticker.C:
 			respDetail, cliErr = m.Client.JobUpdateDetails(updateQ)
 			if cliErr != nil {
-				return false, cliErr
+				return aurora.JobUpdateStatus(-1), cliErr
 			}
 
 			updateDetail := response.JobUpdateDetails(respDetail)
 
 			if len(updateDetail) == 0 {
 				m.Client.RealisConfig().logger.Println("No update found")
-				return false, errors.New("No update found for " + updateKey.String())
+				return aurora.JobUpdateStatus(-1), errors.New("No update found for " + updateKey.String())
 			}
 			status := updateDetail[0].Update.Summary.State.Status
 
-			if _, ok := aurora.ACTIVE_JOB_UPDATE_STATES[status]; !ok {
-
-				// Rolled forward is the only state in which an update has been successfully updated
-				// if we encounter an inactive state and it is not at rolled forward, update failed
-				switch status {
-				case aurora.JobUpdateStatus_ROLLED_FORWARD:
-					m.Client.RealisConfig().logger.Println("Update succeeded")
-					return true, nil
-				case aurora.JobUpdateStatus_FAILED:
-					m.Client.RealisConfig().logger.Println("Update failed")
-					return false, errors.New(UpdateFailed)
-				case aurora.JobUpdateStatus_ROLLED_BACK:
-					m.Client.RealisConfig().logger.Println("rolled back")
-					return false, errors.New(RolledBack)
-				default:
-					return false, nil
-				}
+			if _, ok := desiredStatuses[status]; ok {
+				return status, nil
 			}
+
 		case <-timer.C:
-			return false, errors.New(Timeout)
+			return aurora.JobUpdateStatus(-1), errors.New(Timeout)
 		}
 	}
 }

--- a/monitors.go
+++ b/monitors.go
@@ -24,9 +24,11 @@ import (
 )
 
 const (
-	UpdateFailed = "update failed"
-	RolledBack   = "update rolled back"
-	Timeout      = "timeout"
+	UpdateFailed  = "update failed"
+	RolledBack    = "update rolled back"
+	UpdateAborted = "update aborted"
+	Timeout       = "timeout"
+	UpdateError   = "update encountered an error"
 )
 
 type Monitor struct {
@@ -54,14 +56,20 @@ func (m *Monitor) JobUpdate(updateKey aurora.JobUpdateKey, interval int, timeout
 	// if we encounter an inactive state and it is not at rolled forward, update failed
 	switch status {
 	case aurora.JobUpdateStatus_ROLLED_FORWARD:
-		m.Client.RealisConfig().logger.Println("Update succeeded")
+		m.Client.RealisConfig().logger.Println("update succeeded")
 		return true, nil
-	case aurora.JobUpdateStatus_FAILED:
-		m.Client.RealisConfig().logger.Println("Update failed")
-		return false, errors.New(UpdateFailed)
 	case aurora.JobUpdateStatus_ROLLED_BACK:
-		m.Client.RealisConfig().logger.Println("rolled back")
+		m.Client.RealisConfig().logger.Println(RolledBack)
 		return false, errors.New(RolledBack)
+	case aurora.JobUpdateStatus_ABORTED:
+		m.Client.RealisConfig().logger.Println(UpdateAborted)
+		return false, errors.New(UpdateAborted)
+	case aurora.JobUpdateStatus_ERROR:
+		m.Client.RealisConfig().logger.Println(UpdateError)
+		return false, errors.New(UpdateError)
+	case aurora.JobUpdateStatus_FAILED:
+		m.Client.RealisConfig().logger.Println(UpdateFailed)
+		return false, errors.New(UpdateFailed)
 	default:
 		return false, nil
 	}

--- a/monitors.go
+++ b/monitors.go
@@ -38,13 +38,13 @@ func (m *Monitor) JobUpdate(updateKey aurora.JobUpdateKey, interval int, timeout
 	status, err := m.JobUpdateStatus(updateKey,
 		map[aurora.JobUpdateStatus]bool{
 			aurora.JobUpdateStatus_ROLLED_FORWARD: true,
-			aurora.JobUpdateStatus_ROLLED_BACK: true,
-			aurora.JobUpdateStatus_ABORTED: true,
-			aurora.JobUpdateStatus_ERROR: true,
-			aurora.JobUpdateStatus_FAILED: true,
+			aurora.JobUpdateStatus_ROLLED_BACK:    true,
+			aurora.JobUpdateStatus_ABORTED:        true,
+			aurora.JobUpdateStatus_ERROR:          true,
+			aurora.JobUpdateStatus_FAILED:         true,
 		},
-		time.Duration(interval) * time.Second,
-		time.Duration(timeout) * time.Second)
+		time.Duration(interval)*time.Second,
+		time.Duration(timeout)*time.Second)
 
 	if err != nil {
 		return false, err

--- a/realis.go
+++ b/realis.go
@@ -789,7 +789,7 @@ func (r *realisClient) AbortJobUpdate(updateKey aurora.JobUpdateKey, message str
 
 	// Make this call synchronous by  blocking until it job has successfully transitioned to aborted
 	m := Monitor{Client: r}
-	_, err := m.JobUpdateStatus(updateKey, map[aurora.JobUpdateStatus]bool{aurora.JobUpdateStatus_ABORTED:true},time.Second * 5, time.Minute)
+	_, err := m.JobUpdateStatus(updateKey, map[aurora.JobUpdateStatus]bool{aurora.JobUpdateStatus_ABORTED: true}, time.Second*5, time.Minute)
 
 	if err != nil {
 		return resp, err

--- a/realis.go
+++ b/realis.go
@@ -793,7 +793,7 @@ func (r *realisClient) AbortJobUpdate(updateKey aurora.JobUpdateKey, message str
 	m := Monitor{Client: r}
 	_, err := m.JobUpdateStatus(updateKey, map[aurora.JobUpdateStatus]bool{aurora.JobUpdateStatus_ABORTED: true}, time.Second*5, time.Minute)
 
-    return resp, err
+	return resp, err
 }
 
 //Pause Job Update. UpdateID is returned from StartJobUpdate or the Aurora web UI.

--- a/realis.go
+++ b/realis.go
@@ -775,6 +775,8 @@ func (r *realisClient) StartJobUpdate(updateJob *UpdateJob, message string) (*au
 }
 
 // Abort Job Update on Aurora. Requires the updateId which can be obtained on the Aurora web UI.
+// This API is meant to be synchronous. It will attempt to wait until the update transitions to the aborted state.
+// However, if the job update does not transition to the ABORT state an error will be returned.
 func (r *realisClient) AbortJobUpdate(updateKey aurora.JobUpdateKey, message string) (*aurora.Response, error) {
 
 	r.logger.DebugPrintf("AbortJobUpdate Thrift Payload: %+v %v\n", updateKey, message)
@@ -791,11 +793,7 @@ func (r *realisClient) AbortJobUpdate(updateKey aurora.JobUpdateKey, message str
 	m := Monitor{Client: r}
 	_, err := m.JobUpdateStatus(updateKey, map[aurora.JobUpdateStatus]bool{aurora.JobUpdateStatus_ABORTED: true}, time.Second*5, time.Minute)
 
-	if err != nil {
-		return resp, err
-	} else {
-		return resp, nil
-	}
+    return resp, err
 }
 
 //Pause Job Update. UpdateID is returned from StartJobUpdate or the Aurora web UI.


### PR DESCRIPTION
* AbortJob is now synchronous using a monitor in order to avoid scenarios in which a kill job is sent before the JobUpdate lock is released.