### PR TITLE
Changing how constraints are handled internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-1.22.0 (unreleased)
+1.22.1 (unreleased)
+
+* Adding safeguards against setting multiple constraints with the same name for a single task.
+
+1.22.0
 
 * CreateService and StartJobUpdate do not continue retrying if a timeout has been encountered
 by the HTTP client. Instead they now return an error that conforms to the Timedout interface.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
     ports:
     - "5051:5051"
     environment:
+      MESOS_ATTRIBUTES: 'zone:west'
       MESOS_MASTER: zk://192.168.33.2:2181/mesos
       MESOS_CONTAINERIZERS: docker,mesos
       MESOS_PORT: 5051
@@ -62,6 +63,7 @@ services:
     ports:
       - "5061:5061"
     environment:
+      MESOS_ATTRIBUTES: 'zone:east'
       MESOS_MASTER: zk://192.168.33.2:2181/mesos
       MESOS_CONTAINERIZERS: docker,mesos
       MESOS_HOSTNAME: localhost

--- a/realis_e2e_test.go
+++ b/realis_e2e_test.go
@@ -309,9 +309,9 @@ func TestRealisClient_CreateJob_Thermos(t *testing.T) {
 
 	t.Run("Duplicate_constraints", func(t *testing.T) {
 		job.Name("thermos_duplicate_constraints").
-			AddValueConstraint("hostname", false, "localhost").
-			AddValueConstraint("hostname", false, "localhost1").
-			AddValueConstraint("hostname", true, "west")
+			AddValueConstraint("zone", false, "east", "west").
+			AddValueConstraint("zone", false, "east").
+			AddValueConstraint("zone", true, "west")
 
 		_, err := r.CreateJob(job)
 		require.NoError(t, err)
@@ -326,14 +326,14 @@ func TestRealisClient_CreateJob_Thermos(t *testing.T) {
 
 	t.Run("Overwrite_constraints", func(t *testing.T) {
 		job.Name("thermos_overwrite_constraints").
-			AddLimitConstraint("hostname", 1).
-			AddValueConstraint("hostname", true, "west").
-			AddLimitConstraint("hostname", 1)
+			AddLimitConstraint("zone", 1).
+			AddValueConstraint("zone", true, "west", "east").
+			AddLimitConstraint("zone", 1)
 
 		_, err := r.CreateJob(job)
 		require.NoError(t, err)
 
-		success, err := monitor.Instances(job.JobKey(), 1, 1, 50)
+		success, err := monitor.Instances(job.JobKey(), 2, 1, 50)
 		assert.True(t, success)
 		assert.NoError(t, err)
 

--- a/realis_e2e_test.go
+++ b/realis_e2e_test.go
@@ -333,7 +333,7 @@ func TestRealisClient_CreateJob_Thermos(t *testing.T) {
 		_, err := r.CreateJob(job)
 		require.NoError(t, err)
 
-		success, err := monitor.Instances(job.JobKey(), 2, 1, 50)
+		success, err := monitor.Instances(job.JobKey(), 1, 1, 50)
 		assert.True(t, success)
 		assert.NoError(t, err)
 

--- a/realis_e2e_test.go
+++ b/realis_e2e_test.go
@@ -539,7 +539,7 @@ func TestRealisClient_CreateService(t *testing.T) {
 	timeoutClient, err := realis.NewRealisClient(
 		realis.SchedulerUrl(auroraURL),
 		realis.BasicAuth("aurora", "secret"),
-		realis.TimeoutMS(10),
+		realis.TimeoutMS(5),
 	)
 	require.NoError(t, err)
 	defer timeoutClient.Close()

--- a/realis_e2e_test.go
+++ b/realis_e2e_test.go
@@ -328,7 +328,7 @@ func TestRealisClient_CreateJob_Thermos(t *testing.T) {
 		job.Name("thermos_overwrite_constraints").
 			AddLimitConstraint("zone", 1).
 			AddValueConstraint("zone", true, "west", "east").
-			AddLimitConstraint("zone", 1)
+			AddLimitConstraint("zone", 2)
 
 		_, err := r.CreateJob(job)
 		require.NoError(t, err)

--- a/realis_e2e_test.go
+++ b/realis_e2e_test.go
@@ -306,6 +306,40 @@ func TestRealisClient_CreateJob_Thermos(t *testing.T) {
 		_, err = r.KillJob(job.JobKey())
 		assert.NoError(t, err)
 	})
+
+	t.Run("Duplicate_constraints", func(t *testing.T) {
+		job.Name("thermos_duplicate_constraints").
+			AddValueConstraint("hostname", false, "localhost").
+			AddValueConstraint("hostname", false, "localhost1").
+			AddValueConstraint("hostname", true, "west")
+
+		_, err := r.CreateJob(job)
+		require.NoError(t, err)
+
+		success, err := monitor.Instances(job.JobKey(), 2, 1, 50)
+		assert.True(t, success)
+		assert.NoError(t, err)
+
+		_, err = r.KillJob(job.JobKey())
+		assert.NoError(t, err)
+	})
+
+	t.Run("Overwrite_constraints", func(t *testing.T) {
+		job.Name("thermos_overwrite_constraints").
+			AddLimitConstraint("hostname", 1).
+			AddValueConstraint("hostname", true, "west").
+			AddLimitConstraint("hostname", 1)
+
+		_, err := r.CreateJob(job)
+		require.NoError(t, err)
+
+		success, err := monitor.Instances(job.JobKey(), 2, 1, 50)
+		assert.True(t, success)
+		assert.NoError(t, err)
+
+		_, err = r.KillJob(job.JobKey())
+		assert.NoError(t, err)
+	})
 }
 
 // Test configuring an executor that doesn't exist for CreateJob API


### PR DESCRIPTION
Currently, gorealis allows multiple constraints to be added with the same information. This results in an error when the information is converted to Thrift format. This is another side effect from the change in Thrift from map to slice for sets.

This PR changes how the constraints are stored internally in order to make it impossible to create multiple constraints with the same values.