### PR TITLE
Avoid panics using a forked version while we wait for Thrift to release 0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gorealis [![GoDoc](https://godoc.org/github.com/paypal/gorealis?status.svg)](https://godoc.org/github.com/paypal/gorealis) [![Build Status](https://travis-ci.org/paypal/gorealis.svg?branch=master)](https://travis-ci.org/paypal/gorealis) [![codecov](https://codecov.io/gh/paypal/gorealis/branch/master-v2.0/graph/badge.svg)](https://codecov.io/gh/paypal/gorealis/branch/master-v2.0)
 
-Go library for interacting with [Apache Aurora](https://github.com/apache/aurora).
+Go library for interacting with [Aurora Scheduler](https://github.com/aurora-scheduler/aurora).
 
 ### Aurora version compatibility
 Please see [.auroraversion](./.auroraversion) to see the latest Aurora version against which this
@@ -14,7 +14,7 @@ library has been tested.
 
 ## Projects using gorealis
 
-* [australis](https://github.com/rdelval/australis)
+* [australis](https://github.com/aurora-scheduler/australis)
 
 ## Contributions
 Contributions are always welcome. Please raise an issue to discuss a contribution before it is made.

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/samuel/go-zookeeper v0.0.0-20171117190445-471cd4e61d7a
 	github.com/stretchr/testify v1.2.0
 )
+
+replace github.com/apache/thrift v0.12.0 => github.com/ridv/thrift v0.12.2


### PR DESCRIPTION
Our patch to fix panics in Thrift has landed. We need to wait until 0.14.0 is released to be able to use the fix. While we wait, we can use a patched version of 0.12.0.