### PR TITLE
Allow users to define what extensions CA certs will have

### DIFF
--- a/realis.go
+++ b/realis.go
@@ -321,7 +321,7 @@ func NewRealisClient(options ...ClientOption) (Realis, error) {
 	config.timeoutms = 10000
 	config.backoff = defaultBackoff
 	config.logger = &LevelLogger{logger: log.New(os.Stdout, "realis: ", log.Ltime|log.Ldate|log.LUTC)}
-	config.certExtensions = map[string]struct{}{"crt": {}, "pem": {}, "key": {}}
+	config.certExtensions = map[string]struct{}{".crt": {}, ".pem": {}, ".key": {}}
 
 	// Save options to recreate client if a connection error happens
 	config.options = options

--- a/realis.go
+++ b/realis.go
@@ -18,14 +18,11 @@ package realis
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -117,6 +114,7 @@ type config struct {
 	logger                      *LevelLogger
 	insecureSkipVerify          bool
 	certspath                   string
+	certExtensions              map[string]struct{}
 	clientKey, clientCert       string
 	options                     []ClientOption
 	debug                       bool
@@ -229,6 +227,18 @@ func ClientCerts(clientKey, clientCert string) ClientOption {
 	}
 }
 
+// CertExtensions configures gorealis to consider files with the given extensions when
+// loading certificates from the cert path.
+func CertExtensions(extensions ...string) ClientOption {
+	extensionsLookup := make(map[string]struct{})
+	for _, ext := range extensions {
+		extensionsLookup[ext] = struct{}{}
+	}
+	return func(config *config) {
+		config.certExtensions = extensionsLookup
+	}
+}
+
 // ZookeeperOptions allows users to override default settings for connecting to Zookeeper.
 // See zk.go for what is possible to set as an option.
 func ZookeeperOptions(opts ...ZKOpt) ClientOption {
@@ -311,6 +321,7 @@ func NewRealisClient(options ...ClientOption) (Realis, error) {
 	config.timeoutms = 10000
 	config.backoff = defaultBackoff
 	config.logger = &LevelLogger{logger: log.New(os.Stdout, "realis: ", log.Ltime|log.Ldate|log.LUTC)}
+	config.certExtensions = map[string]struct{}{"crt": {}, "pem": {}, "key": {}}
 
 	// Save options to recreate client if a connection error happens
 	config.options = options
@@ -433,23 +444,6 @@ func GetDefaultClusterFromZKUrl(zkurl string) *Cluster {
 	}
 }
 
-func createCertPool(certPath string) (*x509.CertPool, error) {
-	globalRootCAs := x509.NewCertPool()
-	caFiles, err := ioutil.ReadDir(certPath)
-	if err != nil {
-		return nil, err
-	}
-	for _, cert := range caFiles {
-		caPathFile := filepath.Join(certPath, cert.Name())
-		caCert, err := ioutil.ReadFile(caPathFile)
-		if err != nil {
-			return nil, err
-		}
-		globalRootCAs.AppendCertsFromPEM(caCert)
-	}
-	return globalRootCAs, nil
-}
-
 // Creates a default Thrift Transport object for communications in gorealis using an HTTP Post Client
 func defaultTTransport(url string, timeoutMs int, config *config) (thrift.TTransport, error) {
 	var transport http.Transport
@@ -457,7 +451,7 @@ func defaultTTransport(url string, timeoutMs int, config *config) (thrift.TTrans
 		tlsConfig := &tls.Config{InsecureSkipVerify: config.insecureSkipVerify}
 
 		if config.certspath != "" {
-			rootCAs, err := createCertPool(config.certspath)
+			rootCAs, err := createCertPool(config.certspath, config.certExtensions)
 			if err != nil {
 				config.logger.Println("error occurred couldn't fetch certs")
 				return nil, err

--- a/util.go
+++ b/util.go
@@ -68,12 +68,15 @@ func init() {
 		AwaitingPulseJobUpdateStates[status] = true
 	}
 }
-func createCertPool(path string, extensions map[string]struct{}) (*x509.CertPool, error) {
-	certPool := x509.NewCertPool()
 
+// createCertPool will attempt to load certificates into a certificate pool from a given directory.
+// Only files with an extension contained in the extension map are considered.
+// This function ignores any files that cannot be read successfully or cannot be added to the certPool
+// successfully.
+func createCertPool(path string, extensions map[string]struct{}) (*x509.CertPool, error) {
 	_, err := os.Stat(path)
 	if err != nil {
-		return nil, errors.New("given certs path doesn't exist")
+		return nil, errors.Wrap(err, "unable to load certificates")
 	}
 
 	caFiles, err := ioutil.ReadDir(path)
@@ -81,10 +84,8 @@ func createCertPool(path string, extensions map[string]struct{}) (*x509.CertPool
 		return nil, err
 	}
 
-	if len(caFiles) == 0 {
-		return nil, errors.New("no possible certs found in " + path)
-	}
-
+	certPool := x509.NewCertPool()
+	loadedCerts := 0
 	for _, cert := range caFiles {
 		// Skip directories
 		if cert.IsDir() {
@@ -96,11 +97,17 @@ func createCertPool(path string, extensions map[string]struct{}) (*x509.CertPool
 			continue
 		}
 
-		caCert, err := ioutil.ReadFile(filepath.Join(path, cert.Name()))
+		pem, err := ioutil.ReadFile(filepath.Join(path, cert.Name()))
 		if err != nil {
-			return nil, err
+			continue
 		}
-		certPool.AppendCertsFromPEM(caCert)
+
+		if certPool.AppendCertsFromPEM(pem) {
+			loadedCerts++
+		}
+	}
+	if loadedCerts == 0 {
+		return nil, errors.New("no certificates were able to be successfully loaded")
 	}
 	return certPool, nil
 }
@@ -132,7 +139,7 @@ func validateAuroraURL(location string) (string, error) {
 		return "", errors.Errorf("only protocols http and https are supported %v\n", u.Scheme)
 	}
 
-	// This could theoretically be elsewhwere but we'll be strict for the sake of simplicty
+	// This could theoretically be elsewhere but we'll be strict for the sake of simplicity
 	if u.Path != apiPath {
 		return "", errors.Errorf("expected /api path %v\n", u.Path)
 	}

--- a/util_test.go
+++ b/util_test.go
@@ -100,3 +100,15 @@ func TestCurrentBatchCalculator(t *testing.T) {
 		assert.Equal(t, 0, curBatch)
 	})
 }
+
+func TestCertPoolCreator(t *testing.T) {
+	extensions := map[string]struct{}{"key": {}, "pem": {}, "crt": {}}
+
+	_, err := createCertPool("examples/certs", extensions)
+	assert.NoError(t, err)
+
+	t.Run("badDir", func(t *testing.T) {
+		_, err := createCertPool("idontexist", extensions)
+		assert.Error(t, err)
+	})
+}

--- a/util_test.go
+++ b/util_test.go
@@ -102,7 +102,7 @@ func TestCurrentBatchCalculator(t *testing.T) {
 }
 
 func TestCertPoolCreator(t *testing.T) {
-	extensions := map[string]struct{}{"key": {}, "pem": {}, "crt": {}}
+	extensions := map[string]struct{}{".pem": {}}
 
 	_, err := createCertPool("examples/certs", extensions)
 	assert.NoError(t, err)

--- a/util_test.go
+++ b/util_test.go
@@ -102,7 +102,7 @@ func TestCurrentBatchCalculator(t *testing.T) {
 }
 
 func TestCertPoolCreator(t *testing.T) {
-	extensions := map[string]struct{}{".pem": {}}
+	extensions := map[string]struct{}{".crt": {}}
 
 	_, err := createCertPool("examples/certs", extensions)
 	assert.NoError(t, err)


### PR DESCRIPTION
* New option added to allow users to explicitly set what extensions their CA certs can have.
* Only load files matching those extensions into the Cert pool.