### PR TITLE
Bump up thrift version to v0.13.2

### DIFF
--- a/examples/client.go
+++ b/examples/client.go
@@ -111,7 +111,7 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	monitor = &realis.Monitor{r}
+	monitor = &realis.Monitor{Client: r}
 	defer r.Close()
 
 	switch executor {

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.13
 require (
 	github.com/apache/thrift v0.13.0
 	github.com/davecgh/go-spew v1.1.0
-	github.com/pkg/errors v0.0.0-20171216070316-e881fd58d78e
+	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/samuel/go-zookeeper v0.0.0-20171117190445-471cd4e61d7a
 	github.com/stretchr/testify v1.2.0
 )
 
-replace github.com/apache/thrift v0.13.0 => github.com/ridv/thrift v0.13.1
+replace github.com/apache/thrift v0.13.0 => github.com/ridv/thrift v0.13.2

--- a/realis.go
+++ b/realis.go
@@ -503,10 +503,11 @@ func basicAuth(username, password string) string {
 func (r *realisClient) ReestablishConn() error {
 	// Close existing connection
 	r.logger.Println("Re-establishing Connection to Aurora")
-	r.Close()
 
 	r.lock.Lock()
 	defer r.lock.Unlock()
+
+	r.Close()
 
 	// Recreate connection from scratch using original options
 	newRealis, err := NewRealisClient(r.config.options...)

--- a/retry.go
+++ b/retry.go
@@ -137,7 +137,7 @@ func (r *realisClient) thriftCallWithRetries(
 			}
 
 			r.logger.Printf(
-				"A retryable error occurred during thrift call, backing off for %v before retry %v\n",
+				"A retryable error occurred during thrift call, backing off for %v before retry %v",
 				adjusted,
 				curStep)
 
@@ -154,7 +154,7 @@ func (r *realisClient) thriftCallWithRetries(
 
 			resp, clientErr = thriftCall()
 
-			r.logger.tracePrintf("Aurora Thrift Call ended resp: %v clientErr: %v\n", resp, clientErr)
+			r.logger.tracePrintf("Aurora Thrift Call ended resp: %v clientErr: %v", resp, clientErr)
 		}()
 
 		// Check if our thrift call is returning an error. This is a retryable event as we don't know
@@ -162,7 +162,7 @@ func (r *realisClient) thriftCallWithRetries(
 		if clientErr != nil {
 
 			// Print out the error to the user
-			r.logger.Printf("Client Error: %v\n", clientErr)
+			r.logger.Printf("Client Error: %v", clientErr)
 
 			// Determine if error is a temporary URL error by going up the stack
 			e, ok := clientErr.(thrift.TTransportException)


### PR DESCRIPTION
Forked Thrift version v.013.1 was cached in Google's go proxy with a bug. It looks like modules are immutable so a new version needed to be released in order to remedy this.

This patch also fixes a possible race condition and cleans up some cosmetic issues with the code.