### PR TITLE
Upgrading Mesos to 1.7.2 and Aurora Scheduler to 0.23.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         ipv4_address: 192.168.33.2
 
   master:
-    image: rdelvalle/mesos-master:1.6.2
+    image: aurorascheduler/mesos-master:1.7.2
     restart: on-failure
     ports:
     - "5050:5050"
@@ -32,7 +32,7 @@ services:
     - zk
 
   agent-one:
-    image: rdelvalle/mesos-agent:1.6.2
+    image: aurorascheduler/mesos-agent:1.7.2
     pid: host
     restart: on-failure
     ports:
@@ -57,7 +57,7 @@ services:
     - zk
 
   agent-two:
-    image: rdelvalle/mesos-agent:1.6.2
+    image: aurorascheduler/mesos-agent:1.7.2
     pid: host
     restart: on-failure
     ports:
@@ -82,7 +82,7 @@ services:
       - zk
 
   aurora-one:
-    image: rdelvalle/aurora:0.22.0
+    image: aurorascheduler/scheduler:0.23.0
     pid: host
     ports:
     - "8081:8081"


### PR DESCRIPTION
Docker Compose set up has been upgraded to use Mesos 1.7.2 and Aurora Scheduler 0.23.0.