### PR TITLE
Bug fix for auto paused update monitor

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -168,7 +168,8 @@ func (m *Monitor) AutoPausedUpdateMonitor(key aurora.JobUpdateKey, interval, tim
 		return -1, err
 	}
 
-	if summary[0].State.Status != aurora.JobUpdateStatus_ROLL_FORWARD_PAUSED {
+	if !(summary[0].State.Status == aurora.JobUpdateStatus_ROLL_FORWARD_PAUSED ||
+		summary[0].State.Status == aurora.JobUpdateStatus_ROLLED_FORWARD) {
 		return -1, errors.Errorf("update is in a terminal state %v", summary[0].State.Status)
 	}
 

--- a/realis_e2e_test.go
+++ b/realis_e2e_test.go
@@ -1059,8 +1059,10 @@ func TestRealisClient_BatchAwareAutoPause(t *testing.T) {
 
 		assert.Equal(t, i, curStep)
 
-		_, err = r.ResumeJobUpdate(&key, "auto resuming test")
-		require.NoError(t, err)
+		if i != len(updateGroups)-1 {
+			_, err = r.ResumeJobUpdate(&key, "auto resuming test")
+			require.NoError(t, err)
+		}
 	}
 
 	_, err = r.KillJob(job.JobKey())


### PR DESCRIPTION
Returns success if the update has finished updating successfully.
Previously, this same monitor returned an error due to the the way in which it looked for states.