### PR TITLE
enable default sla for slaDrain

### DIFF
--- a/realis.go
+++ b/realis.go
@@ -129,6 +129,15 @@ var defaultBackoff = Backoff{
 	Jitter:   0.1,
 }
 
+var defaultSlaPolicy = aurora.SlaPolicy{
+	PercentageSlaPolicy: &aurora.PercentageSlaPolicy{
+		Percentage:   66,
+		DurationSecs: 300,
+	},
+}
+
+const defaultSlaDrainTimeoutSecs = 900
+
 // ClientOption is an alias for a function that modifies the realis config object
 type ClientOption func(*config)
 

--- a/realis_admin.go
+++ b/realis_admin.go
@@ -58,6 +58,18 @@ func (r *realisClient) SLADrainHosts(
 		return nil, errors.New("no hosts provided to drain")
 	}
 
+	if policy == nil || policy.CountSetFieldsSlaPolicy() == 0 {
+		policy = &defaultSlaPolicy
+		r.logger.Printf("Warning: start draining with default sla policy %v", policy)
+	}
+
+	if timeout < 0 {
+		r.logger.Printf("Warning: timeout %d secs is invalid, draining with default timeout %d secs",
+			timeout,
+			defaultSlaDrainTimeoutSecs)
+		timeout = defaultSlaDrainTimeoutSecs
+	}
+
 	drainList := aurora.NewHosts()
 	drainList.HostNames = hosts
 

--- a/realis_e2e_test.go
+++ b/realis_e2e_test.go
@@ -750,6 +750,53 @@ func TestRealisClient_SLADrainHosts(t *testing.T) {
 		5,
 		10)
 	assert.NoError(t, err)
+
+	// slaDrainHosts goes with default policy if no policy is specified
+	_, err = r.SLADrainHosts(nil, 30, hosts...)
+	require.NoError(t, err, "unable to drain host with SLA policy")
+
+	// Monitor change to DRAINING and DRAINED mode
+	hostResults, err = monitor.HostMaintenance(
+		hosts,
+		[]aurora.MaintenanceMode{aurora.MaintenanceMode_DRAINED, aurora.MaintenanceMode_DRAINING},
+		1,
+		50)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]bool{"localhost": true}, hostResults)
+
+	_, _, err = r.EndMaintenance(hosts...)
+	require.NoError(t, err)
+
+	// Monitor change to DRAINING and DRAINED mode
+	_, err = monitor.HostMaintenance(
+		hosts,
+		[]aurora.MaintenanceMode{aurora.MaintenanceMode_NONE},
+		5,
+		10)
+	assert.NoError(t, err)
+
+	_, err = r.SLADrainHosts(&aurora.SlaPolicy{}, 30, hosts...)
+	require.NoError(t, err, "unable to drain host with SLA policy")
+
+	// Monitor change to DRAINING and DRAINED mode
+	hostResults, err = monitor.HostMaintenance(
+		hosts,
+		[]aurora.MaintenanceMode{aurora.MaintenanceMode_DRAINED, aurora.MaintenanceMode_DRAINING},
+		1,
+		50)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]bool{"localhost": true}, hostResults)
+
+	_, _, err = r.EndMaintenance(hosts...)
+	require.NoError(t, err)
+
+	// Monitor change to DRAINING and DRAINED mode
+	_, err = monitor.HostMaintenance(
+		hosts,
+		[]aurora.MaintenanceMode{aurora.MaintenanceMode_NONE},
+		5,
+		10)
+	assert.NoError(t, err)
 }
 
 // Test multiple go routines using a single connection


### PR DESCRIPTION
if users do not specify the sla policy, slaDrain will go with the default one.

tests:
unit tests